### PR TITLE
Add elevations scraping and placeholder Elevations control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .Rhistory
 data/
 venv/
+scrapeOutput.log

--- a/python/batch_geojson.py
+++ b/python/batch_geojson.py
@@ -18,3 +18,11 @@ with open("../data/pairwise_routes.json", 'rb') as pr:
             at.write('{{ "type": "Feature", "properties": {{  "id": "{id}", "name":"Along route"}}, "geometry": {{ "type": "Point", "coordinates": {latlong} }} }}\n'.format(id=route, latlong=fc[-1]))
             at.write(']}')
 
+with open("../data/pairwise_elevations.json", 'rb') as pr:
+    original = json.load(pr)
+    for x in original:
+        elevations = x['elevations']
+        route = x['route'].replace(":", "_")
+        outfile = "elevations{}.geojson".format(route)
+        with open(outfile, 'w') as at:
+            at.write(json.dumps(elevations))

--- a/python/get_directions.py
+++ b/python/get_directions.py
@@ -4,6 +4,8 @@ import csv
 from collections import OrderedDict
 import pickle
 import os.path
+import math
+import sys
 
 # https://console.developers.google.com/apis/credentials
 API = ''
@@ -64,10 +66,14 @@ with open('../data/2015_station_data.csv', 'rb') as sd:
         station_data.append(item)
 
 pairwise_directions = []
+pairwise_elevations = []
+totalCombinations = int(math.pow(len(station_data), 2))
 for x in station_data:
     for y in station_data:
         if x != y:
-            print 'getting directions for x: ' + str(x) + ', y: ' + str(y)
+            combinationIndex = station_data.index(x) * len(station_data) + station_data.index(y)
+            prefix = '[' + str(combinationIndex+1) + ' of ' + str(totalCombinations) + ']'
+            print prefix + ' getting directions for x: ' + str(x) + ', y: ' + str(y)
 
             # The Google directions API limits free use to 2500 queries per diem.
             # We'll surpass that, so save the results for each query into files.
@@ -75,10 +81,11 @@ for x in station_data:
             # On the second day, the direction data shall be complete.
             filenameSuffix = x['name'] + '-' + y['name'] + '.dat'
             directionsFilename = '../data/directions/directions-' + filenameSuffix
-            elevationsFilename = '../data/directions/elevations-' + filenameSuffix
+            elevationsFilename = '../data/elevations/elevations-' + filenameSuffix
             if os.path.isfile(directionsFilename) and os.path.isfile(elevationsFilename):
                 print '  loading directions and elevations from file...'
                 dirsDict = pickle.load(open(directionsFilename, "rb"))
+                orderedElevations = pickle.load(open(elevationsFilename, "rb"))
             else:
                 print '  querying gmaps...'
                 item2 = {}
@@ -92,11 +99,15 @@ for x in station_data:
                 pickle.dump(dirsDict, open(directionsFilename, "wb"))
 
                 elevationsDict = {}
-                samples = 10
-                elevationsDict['samples'] = samples
                 elevations = []
+                pathSegments = []
+                pathSegmentDistances = []
+                totalSegmentDistances = 0
+                elevationMapPixels = 300
+                elevationSamplingGranularity = 3
+                totalSamples = elevationMapPixels / elevationSamplingGranularity
 
-                for i in range(0, len(path) - 2):
+                for i in range(len(path) - 2):
                     pathSegment = path[i:i+2]
 
                     transformedPathSegment = []
@@ -104,14 +115,43 @@ for x in station_data:
                     for point in pathSegment:
                         transformedPathSegment.append((point[1], point[0]))
 
-                    segmentElevations = gmaps.elevation_along_path(transformedPathSegment, samples)
+                    pathSegments.append(transformedPathSegment)
 
-                    elevations.append(segmentElevations)
+                    # a^2 + b^2 = c^2
+                    a = transformedPathSegment[1][0] - transformedPathSegment[0][0]
+                    b = transformedPathSegment[1][1] - transformedPathSegment[0][1]
+                    segmentDistance = math.sqrt(math.pow(a, 2) + math.pow(b, 2))
+                    pathSegmentDistances.append(segmentDistance)
+                    totalSegmentDistances += segmentDistance
 
-                elevationsDict['elevations'] = elevations
-                pickle.dump(elevationsDict, open(elevationsFilename, "wb"))
+                for i in range(len(pathSegments)):
+                    percentOfTotal = float(pathSegmentDistances[i]) / float(totalSegmentDistances)
+                    samples = totalSamples * percentOfTotal
+                    samples = max(int(samples) + 1, 2)
+                    print "    querying elevation info for segment " + str(i+1) + " of " + str(len(pathSegments)) + "..."
+                    segmentElevations = gmaps.elevation_along_path(pathSegments[i], samples)
+
+                    if i == 0:
+                        # only append the beginning elevation for the first path segment
+                        elevations.append(segmentElevations[0])
+                    for elevation in segmentElevations[1:]:
+                        elevations.append(elevation)
+
+                cleanedElevations = []
+                for elevation in elevations:
+                    cleanedElevations.append(elevation['elevation'])
+
+                elevationsDict['totalSamples'] = totalSamples
+                elevationsDict['elevations'] = cleanedElevations
+                elevationsDict['route'] = item2['route']
+                orderedElevations = OrderedDict(sorted(elevationsDict.items(), key=lambda t: t[0]))
+                pickle.dump(orderedElevations, open(elevationsFilename, "wb"))
 
             pairwise_directions.append(dirsDict)
+            pairwise_elevations.append(orderedElevations)
 
 with open('../data/pairwise_routes.json', 'w') as pr:
     pr.write(json.dumps(pairwise_directions))
+
+with open('../data/pairwise_elevations.json', 'w') as pr:
+    pr.write(json.dumps(pairwise_elevations))

--- a/scrapeElevations.sh
+++ b/scrapeElevations.sh
@@ -1,0 +1,9 @@
+# crontab entry:
+# 0 13 * * * bash [repo-dir]/scrapeElevations.sh APIKEY1
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR
+rm ./scrapeOutput.log
+source venv/bin/activate
+cd python
+python get_directions.py $1 >> ../scrapeOutput.log 2>&1
+echo "DONE FOR TODAY!"

--- a/static/Elevations.jsx
+++ b/static/Elevations.jsx
@@ -6,29 +6,11 @@ window.Elevations = React.createClass({
       .attr("width", 300)
       .attr("height", 500);
 
+    // Temporary placeholder. Once all geojson elevations data is available,
+    // parameterize this.
     d3.json('elevationsBT-01_CBD-07.geojson', function (elevations) {
       var lineData = [];
-      // var scaleMax = 500;
-      // var scaleMin = 0;
-      // var actualMax = Number.MIN_VALUE;
-      // var actualMin = Number.MAX_VALUE;
-      // for (var i = 0; i < elevations.length; ++i) {
-      //   var elevation = elevations[i];
-      //   if (elevation < actualMin) {
-      //     actualMin = elevation;
-      //   }
-      //   if (elevation > actualMax) {
-      //     actualMax = elevation;
-      //   }
-      // }
-
-      // var delta = actualMax - actualMin;
-      // var scaleFactor = (scaleMax - scaleMin) / delta;
-
-      // var yMin = Number.MAX_VALUE;
-      // var yMax = Number.MIN_VALUE;
       for (var i = 0; i < elevations.length; ++i) {
-        //var y = ((elevations[i] - actualMin) * scaleFactor);
         lineData.push({ x: i*3, y: elevations[i] });
       }
 
@@ -42,40 +24,6 @@ window.Elevations = React.createClass({
         .attr("stroke", "blue")
         .attr("stroke-width", 2)
         .attr("fill", "none");
-
-      //alert("actualMin: " + actualMin + ", actualMax: " + actualMax + ", scaleFactor: " + scaleFactor + ", yMin: " + yMin + ", yMax: " + yMax);
-
-      // plotElevation(elevations);
-
-      // // Takes an array of ElevationResult objects, draws the path on the map
-      // // and plots the elevation profile on a Visualization API ColumnChart.
-      // function plotElevation(elevations) {
-      //   var chartDiv = document.getElementById('otherPlaceholder');
-
-      //   // Create a new chart in the elevation_chart DIV.
-      //   var chart = new google.visualization.ColumnChart(chartDiv);
-
-      //   // Extract the data from which to populate the chart.
-      //   // Because the samples are equidistant, the 'Sample'
-      //   // column here does double duty as distance along the
-      //   // X axis.
-      //   var data = new google.visualization.DataTable();
-      //   data.addColumn('string', 'Sample');
-      //   data.addColumn('number', 'Elevation');
-      //   for (var i = 0; i < elevations.length; i++) {
-      //     data.addRow(['', elevations[i]]);
-
-      //   }
-
-      //   // Draw the chart using the data within its DIV.
-      //   chart.draw(data, {
-      //     height: 150,
-      //     width: 400,
-      //     legend: 'none',
-      //     titleY: 'Elevation (m)'
-      //   });
-      // }
-
     });
   },
   render: function() {
@@ -84,4 +32,3 @@ window.Elevations = React.createClass({
     );
   }
 });
-

--- a/static/Elevations.jsx
+++ b/static/Elevations.jsx
@@ -1,0 +1,87 @@
+
+window.Elevations = React.createClass({
+  componentDidMount: function () {
+    var placeholder = document.getElementById('elevationsPlaceholder');
+    var svg = d3.select(placeholder).append('svg')
+      .attr("width", 300)
+      .attr("height", 500);
+
+    d3.json('elevationsBT-01_CBD-07.geojson', function (elevations) {
+      var lineData = [];
+      // var scaleMax = 500;
+      // var scaleMin = 0;
+      // var actualMax = Number.MIN_VALUE;
+      // var actualMin = Number.MAX_VALUE;
+      // for (var i = 0; i < elevations.length; ++i) {
+      //   var elevation = elevations[i];
+      //   if (elevation < actualMin) {
+      //     actualMin = elevation;
+      //   }
+      //   if (elevation > actualMax) {
+      //     actualMax = elevation;
+      //   }
+      // }
+
+      // var delta = actualMax - actualMin;
+      // var scaleFactor = (scaleMax - scaleMin) / delta;
+
+      // var yMin = Number.MAX_VALUE;
+      // var yMax = Number.MIN_VALUE;
+      for (var i = 0; i < elevations.length; ++i) {
+        //var y = ((elevations[i] - actualMin) * scaleFactor);
+        lineData.push({ x: i*3, y: elevations[i] });
+      }
+
+      var lineFunction = d3.svg.line()
+        .x(function(d) { return d.x; })
+        .y(function(d) { return d.y; })
+        .interpolate("linear");
+
+      var lineGraph = svg.append("path")
+        .attr("d", lineFunction(lineData))
+        .attr("stroke", "blue")
+        .attr("stroke-width", 2)
+        .attr("fill", "none");
+
+      //alert("actualMin: " + actualMin + ", actualMax: " + actualMax + ", scaleFactor: " + scaleFactor + ", yMin: " + yMin + ", yMax: " + yMax);
+
+      // plotElevation(elevations);
+
+      // // Takes an array of ElevationResult objects, draws the path on the map
+      // // and plots the elevation profile on a Visualization API ColumnChart.
+      // function plotElevation(elevations) {
+      //   var chartDiv = document.getElementById('otherPlaceholder');
+
+      //   // Create a new chart in the elevation_chart DIV.
+      //   var chart = new google.visualization.ColumnChart(chartDiv);
+
+      //   // Extract the data from which to populate the chart.
+      //   // Because the samples are equidistant, the 'Sample'
+      //   // column here does double duty as distance along the
+      //   // X axis.
+      //   var data = new google.visualization.DataTable();
+      //   data.addColumn('string', 'Sample');
+      //   data.addColumn('number', 'Elevation');
+      //   for (var i = 0; i < elevations.length; i++) {
+      //     data.addRow(['', elevations[i]]);
+
+      //   }
+
+      //   // Draw the chart using the data within its DIV.
+      //   chart.draw(data, {
+      //     height: 150,
+      //     width: 400,
+      //     legend: 'none',
+      //     titleY: 'Elevation (m)'
+      //   });
+      // }
+
+    });
+  },
+  render: function() {
+    return (
+      <div>elevation profile:</div>
+    );
+  }
+});
+

--- a/static/mountMap.jsx
+++ b/static/mountMap.jsx
@@ -1,12 +1,18 @@
 
 window.markerClickHandler = undefined;
 var StationForm = window.StationForm;
+var Elevations = window.Elevations;
 var Map = window.Map;
 
 var actionUrl = $('#hidden_get_map_link').attr("href");
 ReactDOM.render(
   <StationForm action={actionUrl} />,
   document.getElementById('stationPickerPlaceholder')
+);
+
+ReactDOM.render(
+  <Elevations />,
+  document.getElementById('elevationsPlaceholder')
 );
 
 var route = $('#hidden_route').attr("href");

--- a/templates/map.html
+++ b/templates/map.html
@@ -12,6 +12,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.1.0/react.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.1.0/react-dom.js"></script>
   <script type="text/babel" src="StationPicker.jsx"></script>
+  <script type="text/babel" src="Elevations.jsx"></script>
   <script type="text/babel" src="Map.jsx"></script>
   <script type="text/babel" src="mountMap.jsx"></script>
   <script src={{ url_for('static', filename='stations.js') }}></script>
@@ -50,6 +51,7 @@
 <body>
   <div id='demo' class='col-xs-5'>
     <div id="stationPickerPlaceholder"></div>
+    <div id="elevationsPlaceholder"></div>
     <p>
     {% for entry in entries %}
     <u>Trip start:</u></br>


### PR DESCRIPTION
- Really naive way of scraping elevations data. Probably too granular for a first pass, but oh well.
- We're only able to process a few routes at a time due to Google API limits. Made a cron-able shell script to use with a couple different API keys to fetch the elevations data. Once the elevations data is scraped (may take awhile...), I can commit pairwise_elevations to the repo.
